### PR TITLE
fix: import nuxt composables from #imports

### DIFF
--- a/client/app.vue
+++ b/client/app.vue
@@ -12,7 +12,7 @@
 </template>
 
 <script>
-import { useCookie } from "#app";
+import { useCookie } from "#imports";
 
 export default {
   setup() {

--- a/client/components/RightSidebar.vue
+++ b/client/components/RightSidebar.vue
@@ -50,7 +50,7 @@
 </template>
 
 <script>
-import { useCookie } from "#app";
+import { useCookie } from "#imports";
 import { watch } from "vue";
 
 export default {


### PR DESCRIPTION
This is a DX improvement when developing - we can avoid loading the entire barrel file at `#app` by using the new granular imports merged in https://github.com/nuxt/nuxt/pull/23951.